### PR TITLE
Replace deprecated IconSet and IconFactory

### DIFF
--- a/scantpaper/app.py
+++ b/scantpaper/app.py
@@ -14,7 +14,6 @@
 # refactor methods using self.slist.clipboard
 # refactor ocr & annotation manipulation into single class
 # various improvements from StackOverflow
-# fix deprecation warnings from Gtk.IconSet and Gtk.IconFactory
 # add type hints and turn on type checks in tox.ini
 # migrate to Gtk4
 # remaining FIXMEs and TODOs
@@ -95,25 +94,11 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import (
     Gtk,
-    GdkPixbuf,
     Gio,
     GLib,
 )
 
 # pylint: enable=wrong-import-position
-
-
-def register_icon(iconfactory, stock_id, path):
-    "Add icons"
-    logger = logging.getLogger(__name__)
-    try:
-        icon = GdkPixbuf.Pixbuf.new_from_file(path)
-        if icon is None:
-            logger.warning("Unable to load icon `%s'", path)
-        else:
-            iconfactory.add(stock_id, Gtk.IconSet.new_from_pixbuf(icon))
-    except (FileNotFoundError, OSError, GLib.GError) as err:
-        logger.warning("Unable to load icon `%s': %s", path, err)
 
 
 class Application(Gtk.Application):
@@ -139,24 +124,12 @@ class Application(Gtk.Application):
 
         # Add extra icons early to be available for Gtk.Builder
         # Check for icons in the package first, then fallback to system icons.
-        self.iconpath = os.path.abspath(
+        iconpath = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../icons")
         )
-        if not os.path.isdir(self.iconpath):
-            self.iconpath = "/usr/share/icons"
-        self._init_icons(
-            [
-                ("rotate90", "hicolor/scalable/apps/stock-rotate-90.svg"),
-                ("rotate180", "hicolor/scalable/apps/180_degree.svg"),
-                ("rotate270", "hicolor/scalable/apps/stock-rotate-270.svg"),
-                ("scanner", "hicolor/scalable/apps/scanner.svg"),
-                ("pdf", "hicolor/scalable/apps/pdf.svg"),
-                ("selection", "hicolor/16x16/apps/stock-selection-all-16.png"),
-                ("hand-tool", "hicolor/scalable/apps/hand-tool.svg"),
-                ("mail-attach", "hicolor/scalable/apps/mail-attach.svg"),
-                ("crop", "hicolor/scalable/apps/crop.svg"),
-            ],
-        )
+        if not os.path.isdir(iconpath):
+            iconpath = "/usr/share/scantpaper/icons"
+        Gtk.IconTheme.get_default().prepend_search_path(iconpath)
 
     def do_startup(self, *args, **kwargs):
         Gtk.Application.do_startup(self)
@@ -169,13 +142,6 @@ class Application(Gtk.Application):
         if not self.window:
             self.window = ApplicationWindow(application=self)
         self.window.present()
-
-    def _init_icons(self, icons):
-        "Initialise iconfactory"
-        iconfactory = Gtk.IconFactory()
-        for iconname, filename in icons:
-            register_icon(iconfactory, iconname, self.iconpath + "/" + filename)
-        iconfactory.add_default()
 
 
 def _parse_arguments():

--- a/scantpaper/app.ui
+++ b/scantpaper/app.ui
@@ -546,7 +546,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Scan document</property>
             <property name="action_name">win.scan</property>
-            <property name="stock_id">scanner</property>
+            <property name="icon-name">scanner</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -566,7 +566,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Attach as PDF to a new email</property>
             <property name="action_name">win.email</property>
-            <property name="stock_id">mail-attach</property>
+            <property name="icon-name">mail-attach</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -671,7 +671,7 @@
             <property name="tooltip_text" translatable="yes">Use the pan tool</property>
             <property name="action_name">win.tooltype</property>
             <property name="action-target">'dragger'</property>
-            <property name="stock_id">hand-tool</property>
+            <property name="icon-name">hand-tool</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -683,7 +683,7 @@
             <property name="action_name">win.tooltype</property>
             <property name="group">toolbutton_dragger</property>
             <property name="action-target">'selector'</property>
-            <property name="stock_id">selection</property>
+            <property name="icon-name">stock-selection-all-16</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -747,7 +747,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Rotate 90° clockwise</property>
             <property name="action_name">win.rotate-90</property>
-            <property name="stock_id">rotate90</property>
+            <property name="icon-name">stock-rotate-90</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -757,7 +757,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Rotate 180°</property>
             <property name="action_name">win.rotate-180</property>
-            <property name="stock_id">rotate180</property>
+            <property name="icon-name">stock-rotate-180</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -767,7 +767,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Rotate 90° anticlockwise</property>
             <property name="action_name">win.rotate-270</property>
-            <property name="stock_id">rotate270</property>
+            <property name="icon-name">stock-rotate-270</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>
@@ -778,7 +778,7 @@
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Crop selection</property>
             <property name="action_name">win.crop-selection</property>
-            <property name="stock_id">crop</property>
+            <property name="icon-name">crop</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
           </object>

--- a/scantpaper/app_window.py
+++ b/scantpaper/app_window.py
@@ -178,11 +178,7 @@ class ApplicationWindow(
             if self.settings["window_maximize"]:
                 self.maximize()
 
-        icon = f"{self.get_application().iconpath}/hicolor/scalable/apps/scantpaper.svg"
-        try:
-            self.set_icon_from_file(icon)
-        except (FileNotFoundError, OSError, GLib.Error) as e:
-            logger.warning("Unable to load icon `%s': %s", icon, str(e))
+        self.set_icon_name("scantpaper")
 
         self._thumb_popup = self.builder.get_object("thumb_popup")
 

--- a/scantpaper/tests/test_app.py
+++ b/scantpaper/tests/test_app.py
@@ -7,7 +7,7 @@ import pytest
 
 # Import the module under test
 import app as app_module
-from app import Application, _parse_arguments, main, register_icon, PROG_NAME
+from app import Application, _parse_arguments, main, PROG_NAME
 import gi
 
 gi.require_version("Gtk", "3.0")
@@ -17,7 +17,6 @@ gi.require_version("Gtk", "3.0")
 def mock_deps(mocker):
     "Mock external dependencies"
     mocker.patch("app.Gtk")
-    mocker.patch("app.GdkPixbuf")
 
     # Mock Gio but ensure flags are valid
     mock_gio = mocker.patch("app.Gio")
@@ -44,78 +43,6 @@ def mock_deps(mocker):
     mocker.patch("app.shutil")
     mocker.patch("app.atexit")
     mocker.patch("app.os.remove")
-
-
-def test_register_icon(mock_deps, mocker):
-    "Test register_icon function"
-    iconfactory = MagicMock()
-
-    # Test successful registration
-    mocker.patch("app.GdkPixbuf.Pixbuf.new_from_file", return_value=MagicMock())
-    mocker.patch("app.Gtk.IconSet.new_from_pixbuf", return_value=MagicMock())
-
-    register_icon(iconfactory, "test_id", "test_path")
-
-    app_module.GdkPixbuf.Pixbuf.new_from_file.assert_called_with("test_path")
-    iconfactory.add.assert_called()
-
-    # Test failure (icon is None)
-    mocker.patch("app.GdkPixbuf.Pixbuf.new_from_file", return_value=None)
-    logger = MagicMock()
-    mocker.patch("app.logging.getLogger", return_value=logger)
-
-    register_icon(iconfactory, "test_id", "bad_path")
-
-    logger.warning.assert_called()
-
-
-def test_register_icon_exception(mock_deps, mocker):
-    "Test register_icon exception handling"
-    iconfactory = MagicMock()
-    mocker.patch(
-        "app.GdkPixbuf.Pixbuf.new_from_file", side_effect=FileNotFoundError("Not found")
-    )
-    logger = MagicMock()
-    mocker.patch("app.logging.getLogger", return_value=logger)
-
-    register_icon(iconfactory, "test_id", "bad_path")
-
-    logger.warning.assert_called()
-
-
-def test_application_init(mock_deps):
-    "Test Application.__init__"
-    # Mock os.path.isdir to control icon path logic
-    with patch("os.path.isdir", return_value=True):
-        app = Application()
-        assert app.iconpath == os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "../../icons")
-        )
-        assert app.args == []
-
-    with patch("os.path.isdir", return_value=False):
-        app = Application()
-        assert app.iconpath == "/usr/share/icons"
-
-
-def test_application_init_icons(mock_deps, mocker):
-    "Test Application._init_icons"
-    app = Application()
-
-    mock_icon_factory_cls = mocker.patch("app.Gtk.IconFactory")
-    mock_icon_factory = mock_icon_factory_cls.return_value
-
-    # We need to mock register_icon to verify it is called,
-    # OR we can rely on the mocked Gtk calls inside register_icon if we don't
-    # mock the function itself. Since register_icon is in the same module, we
-    # can mock it at the module level.
-    with patch("app.register_icon") as mock_register:
-        app._init_icons([("name", "file")])
-        mock_register.assert_called_with(
-            mock_icon_factory, "name", app.iconpath + "/file"
-        )
-
-    mock_icon_factory.add_default.assert_called_once()
 
 
 def test_application_do_activate(mock_deps, mocker):

--- a/scantpaper/tests/test_tool_menu_mixins.py
+++ b/scantpaper/tests/test_tool_menu_mixins.py
@@ -966,7 +966,6 @@ def test_about_dialog_runs(mocker, mock_tool_window):
     "Test that ToolsMenuMixins.about runs without error"
 
     mock_about_dialog = mocker.patch("gi.repository.Gtk.AboutDialog")
-    mocker.patch("gi.repository.GdkPixbuf.Pixbuf.new_from_file")
 
     mock_tool_window.get_application().iconpath = "."
 
@@ -980,4 +979,4 @@ def test_about_dialog_runs(mocker, mock_tool_window):
     instance.set_program_name.assert_called()
     instance.set_version.assert_called()
     instance.set_website.assert_called()
-    instance.set_logo.assert_called()
+    instance.set_logo_icon_name.assert_called()

--- a/scantpaper/tools_menu_mixins.py
+++ b/scantpaper/tools_menu_mixins.py
@@ -16,7 +16,6 @@ from postprocess_controls import OCRControls
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import (  # pylint: disable=wrong-import-position
-    GdkPixbuf,
     Gdk,
     GLib,
     Gtk,
@@ -928,11 +927,7 @@ class ToolsMenuMixins:
     """
         about.set_translator_credits(translators)
         about.set_artists(["lodp, Andreas E."])
-        about.set_logo(
-            GdkPixbuf.Pixbuf.new_from_file(
-                f"{self.get_application().iconpath}/hicolor/scalable/apps/scantpaper.svg"
-            )
-        )
+        about.set_logo_icon_name("scantpaper")
         about.set_transient_for(self)
         about.run()
         about.destroy()


### PR DESCRIPTION
Not the end of the icons story. Pulls in the system scanner icon instead. 
Distribute them in a gresource file?
