### PR TITLE
Fix text layer sort combo box

### DIFF
--- a/scantpaper/app_window.py
+++ b/scantpaper/app_window.py
@@ -391,9 +391,8 @@ class ApplicationWindow(
         if args.import_all is not None:
             self._import_files(args.import_all, True)
 
-    def _changed_text_sort_method(self, _widget, data):
-        ocr_index, ocr_text_scmbx = data
-        if ocr_index[ocr_text_scmbx.get_active()][0] == "confidence":
+    def _changed_text_sort_method(self, _widget, sort_method):
+        if sort_method == "confidence":
             self.t_canvas.sort_by_confidence()
         else:
             self.t_canvas.sort_by_position()

--- a/scantpaper/text_layer_control.py
+++ b/scantpaper/text_layer_control.py
@@ -55,7 +55,8 @@ class TextLayerControls(Gtk.Box):
         sort_cmbx = ComboBoxText(data=INDEX)
         sort_cmbx.set_tooltip_text(_("Select sort method for OCR boxes"))
         sort_cmbx.connect(
-            "changed", lambda _: self.emit("sort-changed", sort_cmbx.get_active_text())
+            "changed",
+            lambda _: self.emit("sort-changed", INDEX[sort_cmbx.get_active()][0]),
         )
         sort_cmbx.set_active(0)
         nbutton = Gtk.Button()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "scantpaper/app_window.py", line 395, in _changed_text_sort_method
    ocr_index, ocr_text_scmbx = data
    ^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```
