### PR TITLE
Fix Text layer "+" and "OK" buttons

### DIFF
--- a/scantpaper/session_mixins.py
+++ b/scantpaper/session_mixins.py
@@ -557,7 +557,7 @@ class SessionMixins:
         self.view.handler_unblock(self.view.offset_changed_signal)
 
     def _ocr_text_button_clicked(self, _widget):
-        self._take_snapshot()
+        self.slist.thread._take_snapshot()
         text = self._ocr_text_hbox._textbuffer.get_text(
             self._ocr_text_hbox._textbuffer.get_start_iter(),
             self._ocr_text_hbox._textbuffer.get_end_iter(),
@@ -581,7 +581,7 @@ class SessionMixins:
         self._edit_ocr_text(self._current_ocr_bbox)
 
     def _ocr_text_add(self, _widget):
-        self._take_snapshot()
+        self.slist.thread._take_snapshot()
         text = self._ocr_text_hbox._textbuffer.get_text(
             self._ocr_text_hbox._textbuffer.get_start_iter(),
             self._ocr_text_hbox._textbuffer.get_end_iter(),


### PR DESCRIPTION
`+`
```
  File "scantpaper/session_mixins.py", line 584, in _ocr_text_add
    self._take_snapshot()
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'ApplicationWindow' object has no attribute '_take_snapshot'
```
OK
```
  File "scantpaper/session_mixins.py", line 560, in _ocr_text_button_clicked
    self._take_snapshot()
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'ApplicationWindow' object has no attribute '_take_snapshot'
```

But even with this patch it then stops with a threading problem:

```
Traceback (most recent call last):
  File "scantpaper/session_mixins.py", line 584, in _ocr_text_button_clicked
    self.slist.thread._take_snapshot()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "scantpaper/docthread.py", line 563, in _take_snapshot
    self._check_write_tid()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "scantpaper/docthread.py", line 132, in _check_write_tid
    raise RuntimeError(
    ...<2 lines>...
    )
RuntimeError: Attempted to write to database with tid 636373, but the database was created with tid 636380
```