### PR TITLE
Fix Edit/Copy

### DIFF
--- a/scantpaper/edit_menu_mixins.py
+++ b/scantpaper/edit_menu_mixins.py
@@ -108,7 +108,7 @@ class EditMenuMixins:
 
     def copy_selection(self, _action, _param):
         "Copy the selection"
-        self.slist.clipboard = self.slist.copy_selection(True)
+        self.slist.clipboard = self.slist.copy_selection()
         self._update_uimanager()
 
     def paste_selection(self, _action, _param):


### PR DESCRIPTION
```
  File "scantpaper/edit_menu_mixins.py", line 111, in copy_selection
    self.slist.clipboard = self.slist.copy_selection(True)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
TypeError: BaseDocument.copy_selection() takes 1 positional argument but 2 were given
```
self.slist is a document.Document object.