### PR TITLE
Fix printing

### DIFF
--- a/scantpaper/print_operation.py
+++ b/scantpaper/print_operation.py
@@ -40,7 +40,7 @@ class PrintOperation(Gtk.PrintOperation):
 
     def draw_page_callback(self, _self, context, page_number):
         "draw page"
-        page = self.slist.data[page_number][2]
+        page = self.slist.data[page_number]
         cr = context.get_cairo_context()
 
         # Context dimensions
@@ -48,8 +48,8 @@ class PrintOperation(Gtk.PrintOperation):
         pheight = context.get_height()
 
         # Image dimensions
-        pixbuf = page.get_pixbuf()
-        xresolution, yresolution, _units = page.resolution
+        pixbuf = page[1]
+        xresolution, yresolution = self.slist.get_selected_properties()
         ratio = xresolution / yresolution
         iwidth = pixbuf.get_width()
         iheight = pixbuf.get_height()


### PR DESCRIPTION
```
  File "scantpaper/print_operation.py", line 51, in draw_page_callback
    pixbuf = page.get_pixbuf()
             ^^^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'get_pixbuf'
```

Not quite right. Produces low res output. Hopefully it illustrates the problem.