### PR TITLE
Fix File/Open crashed session

### DIFF
--- a/scantpaper/file_menu_mixins.py
+++ b/scantpaper/file_menu_mixins.py
@@ -255,7 +255,7 @@ class FileMenuMixins:
 
         self.slist.import_files(**options)
 
-    def _open_session_action(self, _action):
+    def _open_session_action(self, _action, _param):
         "open session"
         file_chooser = Gtk.FileChooserDialog(
             title=_("Open crashed session"),


### PR DESCRIPTION
TypeError: FileMenuMixins._open_session_action() takes 2 positional arguments but 3 were given