### PR TITLE
Fix File/New

### DIFF
--- a/scantpaper/app_window.py
+++ b/scantpaper/app_window.py
@@ -193,7 +193,7 @@ class ApplicationWindow(
 
     def _init_actions(self):
         for name, function in [
-            ("new", self.new),
+            ("new", self.new_),
             ("open", self.open_dialog),
             ("open-session", self._open_session_action),
             ("scan", self.scan_dialog),

--- a/scantpaper/file_menu_mixins.py
+++ b/scantpaper/file_menu_mixins.py
@@ -80,7 +80,7 @@ def launch_default_for_file(filename):
 class FileMenuMixins:
     "provide methods called from file menu"
 
-    def new(self, _action, _param):
+    def new_(self, _action, _param):
         "Deletes all scans after warning"
         if not self._pages_saved(
             _("Some pages have not been saved.\nDo you really want to clear all pages?")


### PR DESCRIPTION
TypeError: Gtk.ApplicationWindow.new() takes exactly 1 argument (2 given)

---

But even with this patch it then fails with:

```
Traceback (most recent call last):
  File "scantpaper/file_menu_mixins.py", line 112, in _new
    self._windows.reset_start_page()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'reset_start_page'
```
