### PR TITLE
Stop pytest attempting to collect TestScan

### DIFF
--- a/scantpaper/tests/test_0621_dialog_scan_edit_save.py
+++ b/scantpaper/tests/test_0621_dialog_scan_edit_save.py
@@ -57,6 +57,8 @@ sane_mock = Sane()
 class TestScan(Scan):
     "Test-friendly Scan class"
 
+    __test__ = False
+
     def __init__(self, *args, **kwargs):
         self.thread = MagicMock()
         self.thread.device_handle = MagicMock()


### PR DESCRIPTION
PytestCollectionWarning: cannot collect test class 'TestScan' because it
has a `__init__` constructor (from: scantpaper/tests/test_0621_dialog_scan_edit_save.py)

