### PR TITLE
Remove reference to nonexistent `requirements.txt`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before you begin, make sure you have a local clone of the scantpaper repository 
 ### Prerequisites
 
 - Python 3
-- The python dependencies listed in `requirements.txt` and system-level
+- The python dependencies listed in `pyproject.toml` and system-level
   dependencies given in the `README.md` file.
 
 ### Installation


### PR DESCRIPTION
This file was removed in 7affc05db51ce8be2e0add2ceda2f7b3c116bf84. I believe `pyproject.toml` is the correct place to look now?