### PR TITLE
Skip empty ("None") options when searching for "source"

### DIFF
--- a/scantpaper/scanner/options.py
+++ b/scantpaper/scanner/options.py
@@ -60,7 +60,7 @@ class Options(GObject.Object):
             self.source = self.by_name("source")
         else:
             for option in self.array:
-                if re.search(
+                if option.name is not None and re.search(
                     r"source", option.name, re.MULTILINE | re.DOTALL | re.VERBOSE
                 ):
                     self.source = option


### PR DESCRIPTION
The list of options returned by sanes get_options() may contain entries without a name set ('None'), which will cause an exception to be raised when scanned by re.search() and the whole process will fail. As those options are not what we're looking for, just skip options where name is None in this loop.
A similar pattern has been applied in commit 97fa64ee to scantpaper/scanner/options.py l.158